### PR TITLE
fix(build): correct header installation and origin

### DIFF
--- a/cmake/OxideHelpers.cmake
+++ b/cmake/OxideHelpers.cmake
@@ -65,11 +65,6 @@ function(oxide_add_library)
         target_link_libraries(${_target_name} PRIVATE oxide::build)
     endif()
 
-    # Set public headers for installation
-    set_target_properties(${_target_name} PROPERTIES
-        PUBLIC_HEADER "${_public_headers}"
-    )
-
     # Enable unity build if requested
     if(CMAKE_UNITY_BUILD)
         set_target_properties(${_target_name} PROPERTIES
@@ -87,7 +82,11 @@ function(oxide_add_library)
     install(TARGETS ${_target_name}
         EXPORT OxideTargets
         ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include/oxide/${ARG_NAME}
+    )
+
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/oxide/${ARG_NAME}/
+        DESTINATION include/oxide/${ARG_NAME}
+        FILES_MATCHING PATTERN "*.h"
     )
 endfunction()
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -8,7 +8,7 @@ If you're experienced with C++ and just want to dive in:
 
 ```bash
 # Clone and setup
-git clone https://git.oat.im/oat/oxide.git
+git clone https://github.com/oat-im/oxide.git
 cd oxide
 ./scripts/bootstrap.sh  # or bootstrap.ps1 on Windows
 

--- a/docs/getting-started/building.md
+++ b/docs/getting-started/building.md
@@ -7,7 +7,7 @@ This guide covers building Oxide from source on all supported platforms.
 For the impatient (after [prerequisites](prerequisites.md) are installed):
 
 ```bash
-git clone https://git.oat.im/oat/oxide.git
+git clone https://github.com/oat-im/oxide.git
 cd oxide
 ./scripts/bootstrap.sh           # bootstrap.ps1 on Windows
 cmake --preset debug-linux       # or debug-windows, debug-macos
@@ -19,7 +19,7 @@ cmake --build --preset debug-linux
 ### 1. Clone the Repository
 
 ```bash
-git clone https://git.oat.im/oat/oxide.git
+git clone https://github.com/oat-im/oxide.git
 cd oxide
 ```
 


### PR DESCRIPTION
Fixes CMake header installation path to preserve proper include structure and updates incorrect repository references in documentation.

Changes:
- Fix header install path from include/oxide/${NAME}/ to include/oxide/ to maintain correct #include <oxide/module/header.h> structure
- Update repository URLs from old gitlab to github in docs

Fixes build system integration issues and documentation accuracy.