### PR TITLE
bug(core): gcc-8+ doesn't fully support [[nodiscard]]

### DIFF
--- a/cmake/OxideHelpers.cmake
+++ b/cmake/OxideHelpers.cmake
@@ -541,7 +541,7 @@ function(oxide_setup_build_interface)
         )
     else()
         target_compile_options(oxide_build INTERFACE
-            -Wall -Wextra -Werror
+            -Wall -Wextra -Wunused-result -Werror
         )
 
         target_compile_options(oxide_build INTERFACE

--- a/cmake/OxideHelpers.cmake
+++ b/cmake/OxideHelpers.cmake
@@ -171,6 +171,7 @@ function(oxide_add_library)
         target_compile_options(oxide_${ARG_NAME} PRIVATE
             /wd4251  # 'type' needs to have dll-interface
             /wd4275  # non dll-interface base class
+            /wd5030  # unrecognized attribute (gnu::...)
         )
     endif()
 
@@ -308,6 +309,7 @@ function(oxide_add_application)
         target_compile_options(${ARG_NAME} PRIVATE
             /wd4251  # 'type' needs to have dll-interface
             /wd4275  # non dll-interface base class
+            /wd5030  # unrecognized attribute (gnu::...)
         )
     endif()
 
@@ -408,6 +410,7 @@ function(oxide_add_test)
         target_compile_options(${ARG_NAME} PRIVATE
             /wd4251  # 'type' needs to have dll-interface
             /wd4275  # non dll-interface base class
+            /wd5030  # unrecognized attribute (gnu::...)
         )
     endif()
 

--- a/docs/contributing/ai-policy.md
+++ b/docs/contributing/ai-policy.md
@@ -154,7 +154,8 @@ auto result = some_complex_ai_generated_function_i_dont_understand();
 // ✅ Good: Understand and improve AI suggestions
 // AI suggested basic version, but I added error handling and
 // adapted to our Error/std::expected pattern
-[[nodiscard]]
+[[nodiscard, gnu::warn_unused_result]]
+
 std::expected<ProcessedData, Error> processData(BufferView input) {
     if (input.empty()) {
         return std::unexpected(Error(ErrorCode::InvalidInput));

--- a/docs/contributing/code-review.md
+++ b/docs/contributing/code-review.md
@@ -164,7 +164,8 @@ for (auto it = vec.begin(); it != vec.end(); it++) {
 - [ ] No naked `new`/`delete` - use `std::unique_ptr`
 - [ ] Factory functions return `std::expected<std::unique_ptr<T>, Error>`
 - [ ] No exceptions escaping module boundaries
-- [ ] Proper `[[nodiscard]]` usage
+- [ ] Proper `[[nodiscard, gnu::warn_unused_result]]
+` usage
 - [ ] Interface segregation (pure virtual interfaces)
 - [ ] No `std::shared_ptr` without justification
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -160,7 +160,8 @@ class RendererImpl : public IRenderer {
 ```
 
 ### 4. **Explicit Error Handling**
-Every fallible operation returns `std::expected<T, Error>` and is marked `[[nodiscard]]`.
+Every fallible operation returns `std::expected<T, Error>` and is marked `[[nodiscard, gnu::warn_unused_result]]
+`.
 
 ## Common Tasks
 

--- a/docs/development/cpp-manual-short.md
+++ b/docs/development/cpp-manual-short.md
@@ -16,14 +16,15 @@
 ### API Design
 - **struct for POD** - Simple value types with public constructors
 - **class for complex** - Stateful objects with private constructors + factories
-- **[[nodiscard]]** - On all functions that return errors
+- **[[nodiscard, gnu::warn_unused_result]]
+** - On all functions that return errors
 
 ### Error Handling
 ```cpp
 enum class ErrorCode { Ok, InvalidArgument, ... };
 struct Error { ErrorCode code; std::string msg; };
 
-[[nodiscard("Handle this result!")]]
+[[nodiscard("Handle this result!"), gnu::warn_unused_result]]
 std::expected<std::unique_ptr<IFoo>, Error> create_foo();
 ```
 
@@ -36,7 +37,8 @@ public:
     virtual void log(std::string_view msg) = 0;
 };
 
-[[nodiscard]] std::expected<std::unique_ptr<ILogger>, Error> 
+[[nodiscard, gnu::warn_unused_result]]
+ std::expected<std::unique_ptr<ILogger>, Error> 
 create_logger(const Config& cfg);
 
 // Implementation (private)
@@ -89,6 +91,7 @@ tests/                   # Integration tests using public APIs
 
 ## Enforcement
 - All factory functions catch exceptions → return Error
-- [[nodiscard]] on all fallible operations
+- [[nodiscard, gnu::warn_unused_result]]
+ on all fallible operations
 - Static asserts for struct sizes
 - No dynamic_cast (RTTI disabled)

--- a/docs/development/cpp-manual.md
+++ b/docs/development/cpp-manual.md
@@ -149,7 +149,7 @@ All runtime code SHALL use `std::expected` for error propagation. See API.3 for 
 ```cpp
 // Example of catching an internal exception in a factory
 // static
-[[nodiscard("Handle this result! Failure to do so is a bug.")]]
+[[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
 std::expected<std::unique_ptr<MyObject>, Error> MyObject::Create(const std::string& config_data) {
     try {
         // MyObjectImpl constructor might throw on bad config_data
@@ -186,7 +186,7 @@ public:
     virtual ~MyObject() = default;
 
     // Factory function
-    [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+    [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
     static std::expected<std::unique_ptr<MyObject>, Error> Create(...);
 
 protected:
@@ -282,7 +282,7 @@ These layers establish strict boundaries crucial for maintainability, testabilit
 
             virtual void tick(uint64_t now_ns) = 0;
 
-            [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+            [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
             virtual std::expected<void, Error> sendMessage(BufferView payload) = 0;
             // ... other interface methods
         };
@@ -559,15 +559,15 @@ private:
 ```cpp
 class DataProcessor {
 public:
-    [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+    [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
     static std::expected<std::unique_ptr<DataProcessor>, Error> Create(Config& cfg);
 
     void submit_data(BufferView data);
     
-    [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+    [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
     bool is_processing() const;
 
-    [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+    [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
     std::optional<Result> get_result();
 
 private:
@@ -775,7 +775,7 @@ public:
 
 class ILoggerFactory {
 public:
-    [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+    [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
     virtual std::expected<std::unique_ptr<ILogger>, Error> createLogger() = 0;
     virtual ~ILoggerFactory() = default;
 };
@@ -798,7 +798,7 @@ public:
         stream_ << msg << '\n';
     }
 
-    [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+    [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
     static std::expected<std::unique_ptr<ILogger>, Error> Create(std::string_view path) {
         try {
             auto logger = std::unique_ptr<ConcreteLogger>(new ConcreteLogger(path));
@@ -838,7 +838,7 @@ private:
 
 class ConcreteLoggerFactory : public ILoggerFactory {
 public:
-    [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+    [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
     std::expected<std::unique_ptr<ILogger>, Error> createLogger() override {
         return ConcreteLogger::Create("log.txt");
     }
@@ -888,7 +888,7 @@ void reset_logger_factory() {
   class MockLogger : public ILogger { /* ... */ };
   class MockLoggerFactory : public ILoggerFactory {
   public:  
-      [[nodiscard("Handle this result! Failure to do so is a bug.")]]
+      [[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
       std::expected<std::unique_ptr<ILogger>, Error> createLogger() override {
           return std::make_unique<MockLogger>();
       }
@@ -997,7 +997,8 @@ This keeps the API surface clean and makes it immediately obvious what's a value
 
 ---
 
-### API.4: **Error Handling: Use Tagged `Error` Wrappers with `ErrorCode` and `[[nodiscard]]`**
+### API.4: **Error Handling: Use Tagged `Error` Wrappers with `ErrorCode` and `[[nodiscard, gnu::warn_unused_result]]
+`**
 
 <a name="api4-error-codes"></a>
 
@@ -1079,7 +1080,7 @@ namespace oat::foo {
         Error(ErrorCode c, const std::exception& e) noexcept : code(c), message(concat(c, e.what())) {}
         Error(ErrorCode c, std::string msg) noexcept : code(c), message(concat(c, std::move(msg))) {}
     
-        [[nodiscard("You're ignoring an error message. Don't do that.")]]
+        [[nodiscard("You're ignoring an error message. Don't do that."), gnu::warn_unused_result]]
         std::string_view what() const noexcept {
             if (!message.empty()) {
                 return message;
@@ -1088,7 +1089,7 @@ namespace oat::foo {
             }
         }
     
-        [[nodiscard("If you're going to use this, you should probably do something with it.")]]
+        [[nodiscard("If you're going to use this, you should probably do something with it."), gnu::warn_unused_result]]
         ErrorCode code_value() const noexcept { return code; }
     
         bool operator==(ErrorCode other) const noexcept { return code == other; }
@@ -1134,7 +1135,7 @@ namespace oat::foo {
 
 Example for usage:
 ```cpp
-[[nodiscard("Ignoring this means you don't care about the result. Fix it.")]]
+[[nodiscard("Ignoring this means you don't care about the result. Fix it."), gnu::warn_unused_result]]
 std::expected<void, oat::foo::Error> always_fails() {
     return std::unexpected(oat::foo::ErrorCode::InvalidAddress);
 }
@@ -1142,13 +1143,14 @@ std::expected<void, oat::foo::Error> always_fails() {
 
 ---
 
-#### 3. Always Use `[[nodiscard]]` on Functions Returning `std::expected`
+#### 3. Always Use `[[nodiscard, gnu::warn_unused_result]]
+` on Functions Returning `std::expected`
 
 ```cpp
-[[nodiscard("Handle this result! Failure to do so is a bug.")]]
+[[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
 std::expected<Widget, Error> CreateWidget(std::string_view name);
 
-[[nodiscard("Handle this result! Failure to do so is a bug.")]]
+[[nodiscard("Handle this result! Failure to do so is a bug."), gnu::warn_unused_result]]
 std::expected<void, Error> SendMessage(const Widget& w, std::string_view msg);
 ```
 
@@ -1159,7 +1161,7 @@ Failing to check these results MUST trigger compiler warnings or errors. If your
 #### 4. Void Results Use `std::expected<void, Error>`
 
 ```cpp
-[[nodiscard("You must handle this shutdown result.")]]
+[[nodiscard("You must handle this shutdown result."), gnu::warn_unused_result]]
 std::expected<void, Error> Shutdown();
 ```
 
@@ -1168,7 +1170,7 @@ std::expected<void, Error> Shutdown();
 #### 5. Catch and Wrap Errors Properly
 
 ```cpp
-[[nodiscard("Handle this CreateAddr result!")]]
+[[nodiscard("Handle this CreateAddr result!"), gnu::warn_unused_result]]
 std::expected<Addr, Error> CreateAddr(const std::string& ip, uint16_t port) {
     try {
         return Addr(ip, port);
@@ -1209,7 +1211,8 @@ This is a modern, explicitly-typed, contract-driven system. You will not hide er
 
 | Rule                                                 | Enforcement                                  |
 | ---------------------------------------------------- | -------------------------------------------- |
-| All `std::expected` returns SHALL be `[[nodiscard]]` | Compiler will warn or error                  |
+| All `std::expected` returns SHALL be `[[nodiscard, gnu::warn_unused_result]]
+` | Compiler will warn or error                  |
 | All failures use `std::unexpected<Error>`            | No bare `std::unexpected` without an `Error` |
 | Errors MUST support equality with `ErrorCode`        | Required by `Error` wrapper                  |
 | Ignoring failures is a compile-time defect           | Not just discouraged—prohibited              |

--- a/docs/development/creating-apps.md
+++ b/docs/development/creating-apps.md
@@ -145,7 +145,7 @@ public:
     };
     
     // Factory
-    [[nodiscard("Handle creation failure")]]
+    [[nodiscard("Handle creation failure"), gnu::warn_unused_result]]
     static std::expected<std::unique_ptr<Application>, oxide::core::Error> 
     Create(const Config& config);
     
@@ -158,7 +158,8 @@ public:
 private:
     Application(const Config& config);
     
-    [[nodiscard]]
+    [[nodiscard, gnu::warn_unused_result]]
+
     std::expected<void, oxide::core::Error> initialize();
     
     void update(float delta_time);

--- a/docs/development/creating-libraries.md
+++ b/docs/development/creating-libraries.md
@@ -67,7 +67,7 @@ namespace oxide::your_library {
 class IYourInterface;
 
 // Factory function declaration
-[[nodiscard("Handle the result")]]
+[[nodiscard("Handle the result"), gnu::warn_unused_result]]
 std::expected<std::unique_ptr<IYourInterface>, core::Error> 
 makeYourInterface(/* parameters */);
 
@@ -79,7 +79,7 @@ public:
     // Core functionality
     virtual void doSomething() = 0;
     
-    [[nodiscard("Check the result")]]
+    [[nodiscard("Check the result"), gnu::warn_unused_result]]
     virtual std::expected<int, core::Error> computeValue() = 0;
     
     // No implementation details in interface!
@@ -159,7 +159,7 @@ namespace oxide::your_library::detail {
 class YourImplementation final : public IYourInterface {
 public:
     // Factory method
-    [[nodiscard("Handle the result")]]
+    [[nodiscard("Handle the result"), gnu::warn_unused_result]]
     static std::expected<std::unique_ptr<YourImplementation>, core::Error> 
     Create(/* parameters */);
     
@@ -420,7 +420,8 @@ Any important implementation details...
 - ✅ Keep interfaces minimal and focused
 - ✅ Hide all implementation details
 - ✅ Use `std::expected` for all fallible operations
-- ✅ Mark functions `[[nodiscard]]` when appropriate
+- ✅ Mark functions `[[nodiscard, gnu::warn_unused_result]]
+` when appropriate
 - ✅ Follow the dependency hierarchy strictly
 - ✅ Write comprehensive tests
 - ✅ Document the public API

--- a/docs/getting-started/first-app.md
+++ b/docs/getting-started/first-app.md
@@ -95,7 +95,8 @@ using namespace oxide;
 
 class CubeViewerApp {
 public:
-    [[nodiscard]]
+    [[nodiscard, gnu::warn_unused_result]]
+
     static std::expected<std::unique_ptr<CubeViewerApp>, core::Error> Create() {
         auto app = std::unique_ptr<CubeViewerApp>(new CubeViewerApp());
         
@@ -168,7 +169,8 @@ public:
 private:
     CubeViewerApp() = default;
     
-    [[nodiscard]]
+    [[nodiscard, gnu::warn_unused_result]]
+
     std::expected<void, core::Error> setupCube() {
         // Cube vertices (position + color)
         struct Vertex {

--- a/libs/core/include/oxide/core/buffer/buffer_factory.h
+++ b/libs/core/include/oxide/core/buffer/buffer_factory.h
@@ -8,13 +8,13 @@
 namespace oxide::core {
 
 // Factory function to create a dynamic buffer with an optional initial capacity
-[[nodiscard("Handle buffer creation result")]]
+[[nodiscard("Handle buffer creation result"), gnu::warn_unused_result]]
 OXIDE_CORE_API std::expected<std::unique_ptr<IBuffer>, Error>
 create_buffer(std::size_t initial_capacity = 0);
 
 // Factory function to create a static buffer with a fixed size
 template <std::size_t N>
-[[nodiscard("Handle static buffer creation result")]]
+[[nodiscard("Handle static buffer creation result"), gnu::warn_unused_result]]
 std::expected<std::unique_ptr<IBuffer>, Error>
 create_static_buffer() {
     return std::make_unique<detail::StaticBuffer<N>>();

--- a/libs/core/include/oxide/core/buffer/i_buffer.h
+++ b/libs/core/include/oxide/core/buffer/i_buffer.h
@@ -11,31 +11,31 @@ class OXIDE_CORE_API IBuffer {
 public:
     virtual ~IBuffer() = default;
 
-    [[nodiscard("Handle resize result")]]
+    [[nodiscard("Handle resize result"), gnu::warn_unused_result]]
     virtual std::expected<void, Error> resize(std::size_t bytes) = 0;
 
-    [[nodiscard("Handle reserve result")]]
+    [[nodiscard("Handle reserve result"), gnu::warn_unused_result]]
     virtual std::expected<void, Error> reserve(std::size_t bytes) = 0;
 
-    [[nodiscard("Handle clear result")]]
+    [[nodiscard("Handle clear result"), gnu::warn_unused_result]]
     virtual std::expected<void, Error> clear() = 0;
 
-    [[nodiscard("Handle shrink result")]]
+    [[nodiscard("Handle shrink result"), gnu::warn_unused_result]]
     virtual std::expected<void, Error> shrink_to_fit() = 0;
 
-    [[nodiscard("Handle append result")]]
+    [[nodiscard("Handle append result"), gnu::warn_unused_result]]
     virtual std::expected<void, Error> append(std::span<const std::byte> src) = 0;
 
-    [[nodiscard("Handle view result")]]
+    [[nodiscard("Handle view result"), gnu::warn_unused_result]]
     virtual std::span<const std::byte> view() const noexcept = 0;
 
-    [[nodiscard("Handle mutate result")]]
+    [[nodiscard("Handle mutate result"), gnu::warn_unused_result]]
     virtual std::span<      std::byte> mutate() noexcept      = 0;
 
-    [[nodiscard("Handle size result")]]
+    [[nodiscard("Handle size result"), gnu::warn_unused_result]]
     virtual std::size_t size() const noexcept = 0;
 
-    [[nodiscard("Handle capacity result")]]
+    [[nodiscard("Handle capacity result"), gnu::warn_unused_result]]
     virtual std::size_t capacity() const noexcept = 0;
 };
 

--- a/libs/core/include/oxide/core/error/error_impl.h
+++ b/libs/core/include/oxide/core/error/error_impl.h
@@ -186,10 +186,10 @@ struct OXIDE_CORE_API Error
     Error(ErrorCode c, std::string_view m)         : code(c), message(m) {}
     Error(ErrorCode c, const std::exception& e) noexcept : code(c), message(e.what()) {}
 
-    [[nodiscard("Check error state")]]
+    [[nodiscard("Check error state"), gnu::warn_unused_result]]
     constexpr bool ok() const noexcept { return code == ErrorCode::Ok; }
 
-    [[nodiscard("Error message should be used")]]
+    [[nodiscard("Error message should be used"), gnu::warn_unused_result]]
     std::string_view what() const noexcept;
 
 private:

--- a/libs/core/include/oxide/core/logging/logger.h
+++ b/libs/core/include/oxide/core/logging/logger.h
@@ -28,7 +28,8 @@ public:
             std::vformat(fmt, std::make_format_args(std::forward<Args>(args)...)));
     }
     
-    [[nodiscard]]
+    [[nodiscard, gnu::warn_unused_result]]
+
     virtual bool isEnabled(LogLevel level) const = 0;
 };
 

--- a/libs/core/include/oxide/core/store/i_store.h
+++ b/libs/core/include/oxide/core/store/i_store.h
@@ -73,7 +73,7 @@ public:
      * @param path Filesystem path to open.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on open")]]
+    [[nodiscard("Check for error on open"), gnu::warn_unused_result]]
     virtual std::expected<void, Error>
     open(std::filesystem::path const& path) = 0;
 
@@ -81,7 +81,7 @@ public:
      * @brief Closes the store.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on close")]]
+    [[nodiscard("Check for error on close"), gnu::warn_unused_result]]
     virtual std::expected<void, Error>
     close() = 0;
 
@@ -89,7 +89,7 @@ public:
      * @brief Begins a new transaction on the store.
      * @return Unique pointer to ITransaction or error.
      */
-    [[nodiscard("Check for error or valid transaction")]]
+    [[nodiscard("Check for error or valid transaction"), gnu::warn_unused_result]]
     virtual std::expected<std::unique_ptr<class ITransaction>, Error>
     begin_transaction() = 0;
 };
@@ -101,7 +101,7 @@ public:
  * @param opts Options for the JSON store.
  * @return Unique pointer to IStore or error.
  */
-[[nodiscard("Check for error or valid store")]]
+[[nodiscard("Check for error or valid store"), gnu::warn_unused_result]]
 OXIDE_CORE_API std::expected<std::unique_ptr<IStore>, Error>
 make_json_file_store(std::filesystem::path const&, JsonStoreOptions);
 
@@ -111,7 +111,7 @@ make_json_file_store(std::filesystem::path const&, JsonStoreOptions);
  * @param opts Options for the TOML store.
  * @return Unique pointer to IStore or error.
  */
-[[nodiscard("Check for error or valid store")]]
+[[nodiscard("Check for error or valid store"), gnu::warn_unused_result]]
 OXIDE_CORE_API std::expected<std::unique_ptr<IStore>, Error>
 make_toml_file_store(std::filesystem::path const&, TomlStoreOptions);
 
@@ -119,7 +119,7 @@ make_toml_file_store(std::filesystem::path const&, TomlStoreOptions);
  * @brief Creates an in-memory store.
  * @return Unique pointer to IStore or error.
  */
-[[nodiscard("Check for error or valid store")]]
+[[nodiscard("Check for error or valid store"), gnu::warn_unused_result]]
 OXIDE_CORE_API std::expected<std::unique_ptr<IStore>, Error>
 make_in_memory_store();
 

--- a/libs/core/include/oxide/core/store/i_transaction.h
+++ b/libs/core/include/oxide/core/store/i_transaction.h
@@ -47,7 +47,7 @@ public:
      * @brief Returns the root handle of the storage tree.
      * @return StoreHandle on success, or an error (e.g. IoFailure) on failure.
      */
-    [[nodiscard("Check for error or valid root handle")]]
+    [[nodiscard("Check for error or valid root handle"), gnu::warn_unused_result]]
     virtual std::expected<StoreHandle, Error> root() const = 0;
 
     /**
@@ -55,7 +55,7 @@ public:
      * @param h The handle to query.
      * @return The boolean value or an error.
      */
-    [[nodiscard("Check for error or valid bool value")]]
+    [[nodiscard("Check for error or valid bool value"), gnu::warn_unused_result]]
     virtual std::expected<bool,Error>
     get_bool   (StoreHandle h) const = 0;
 
@@ -64,7 +64,7 @@ public:
      * @param h The handle to query.
      * @return The integer value or an error.
      */
-    [[nodiscard("Check for error or valid int value")]]
+    [[nodiscard("Check for error or valid int value"), gnu::warn_unused_result]]
     virtual std::expected<int64_t,Error>
     get_int    (StoreHandle h) const = 0;
 
@@ -73,7 +73,7 @@ public:
      * @param h The handle to query.
      * @return The double value or an error.
      */
-    [[nodiscard("Check for error or valid double value")]]
+    [[nodiscard("Check for error or valid double value"), gnu::warn_unused_result]]
     virtual std::expected<double,Error>
     get_double (StoreHandle h) const = 0;
 
@@ -82,7 +82,7 @@ public:
      * @param h The handle to query.
      * @return The string value or an error.
      */
-    [[nodiscard("Check for error or valid string value")]]
+    [[nodiscard("Check for error or valid string value"), gnu::warn_unused_result]]
     virtual std::expected<std::string,Error>
     get_string (StoreHandle h) const = 0;
 
@@ -92,7 +92,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on set_bool")]]
+    [[nodiscard("Check for error on set_bool"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     set_bool   (StoreHandle h, bool   v) = 0;
 
@@ -102,7 +102,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on set_int")]]
+    [[nodiscard("Check for error on set_int"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     set_int    (StoreHandle h, int64_t v) = 0;
 
@@ -112,7 +112,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on set_double")]]
+    [[nodiscard("Check for error on set_double"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     set_double (StoreHandle h, double  v) = 0;
 
@@ -122,7 +122,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on set_string")]]
+    [[nodiscard("Check for error on set_string"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     set_string (StoreHandle h, std::string_view v) = 0;
 
@@ -132,7 +132,7 @@ public:
      * @param key The key for the new array.
      * @return Handle to the new array or error.
      */
-    [[nodiscard("Check for error or valid array handle")]]
+    [[nodiscard("Check for error or valid array handle"), gnu::warn_unused_result]]
     virtual std::expected<StoreHandle,Error>
     make_array  (StoreHandle parent, std::string_view key) = 0;
 
@@ -142,7 +142,7 @@ public:
      * @param key The key for the new object.
      * @return Handle to the new object or error.
      */
-    [[nodiscard("Check for error or valid object handle")]]
+    [[nodiscard("Check for error or valid object handle"), gnu::warn_unused_result]]
     virtual std::expected<StoreHandle,Error>
     make_object (StoreHandle parent, std::string_view key) = 0;
 
@@ -153,7 +153,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on make_bool")]]
+    [[nodiscard("Check for error on make_bool"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     make_bool   (StoreHandle parent, std::string_view key, bool   v) = 0;
 
@@ -164,7 +164,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on make_int")]]
+    [[nodiscard("Check for error on make_int"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     make_int    (StoreHandle parent, std::string_view key, int64_t v) = 0;
 
@@ -175,7 +175,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on make_double")]]
+    [[nodiscard("Check for error on make_double"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     make_double (StoreHandle parent, std::string_view key, double  v) = 0;
 
@@ -186,7 +186,7 @@ public:
      * @param v The value to set.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on make_string")]]
+    [[nodiscard("Check for error on make_string"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     make_string (StoreHandle parent, std::string_view key, std::string_view v) = 0;
 
@@ -196,7 +196,7 @@ public:
      * @param key The key to remove.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on remove")]]
+    [[nodiscard("Check for error on remove"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     remove        (StoreHandle parent, std::string_view key) = 0;
 
@@ -206,7 +206,7 @@ public:
      * @param key The key to check.
      * @return True if exists, false otherwise, or error.
      */
-    [[nodiscard("Check for error or existence result")]]
+    [[nodiscard("Check for error or existence result"), gnu::warn_unused_result]]
     virtual std::expected<bool,Error>
     has           (StoreHandle parent, std::string_view key) const = 0;
 
@@ -216,7 +216,7 @@ public:
      * @param idx The index to remove.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on erase_element")]]
+    [[nodiscard("Check for error on erase_element"), gnu::warn_unused_result]]
     virtual std::expected<void,Error>
     erase_element (StoreHandle parent, size_t idx) = 0;
 
@@ -226,7 +226,7 @@ public:
      * @param idx The index to check.
      * @return True if exists, false otherwise, or error.
      */
-    [[nodiscard("Check for error or existence result")]]
+    [[nodiscard("Check for error or existence result"), gnu::warn_unused_result]]
     virtual std::expected<bool,Error>
     has_element   (StoreHandle parent, size_t idx) const = 0;
 
@@ -236,7 +236,7 @@ public:
      * @param key The key to retrieve.
      * @return The child handle or error.
      */
-    [[nodiscard("Check for error or valid child handle")]]
+    [[nodiscard("Check for error or valid child handle"), gnu::warn_unused_result]]
     virtual std::expected<StoreHandle,Error>
     child   (StoreHandle parent, std::string_view key) const = 0;
 
@@ -246,7 +246,7 @@ public:
      * @param idx The index to retrieve.
      * @return The element handle or error.
      */
-    [[nodiscard("Check for error or valid element handle")]]
+    [[nodiscard("Check for error or valid element handle"), gnu::warn_unused_result]]
     virtual std::expected<StoreHandle,Error>
     element (StoreHandle parent, size_t idx) const = 0;
 
@@ -254,7 +254,7 @@ public:
      * @brief Commits the transaction, making all changes durable.
      * @return Success or error.
      */
-    [[nodiscard("Check for error on commit")]]
+    [[nodiscard("Check for error on commit"), gnu::warn_unused_result]]
     std::expected<void,Error> commit() {
         auto e = commit_impl();
         if (e) committed_ = true;
@@ -269,7 +269,7 @@ public:
      * @param path The navigation path (e.g. "foo.bar[2].baz").
      * @return The resulting handle or error.
      */
-    [[nodiscard("Check for error or valid navigation result")]]
+    [[nodiscard("Check for error or valid navigation result"), gnu::warn_unused_result]]
     std::expected<StoreHandle,Error>
     navigate(StoreHandle base, std::string_view path) const {
         if (!base.valid()) return std::unexpected(ErrorCode::InvalidHandle);
@@ -313,7 +313,7 @@ public:
      * @return The value or error.
      */
     template<typename T>
-    [[nodiscard("Check for error or valid value")]]
+    [[nodiscard("Check for error or valid value"), gnu::warn_unused_result]]
     std::expected<T,Error>
     get(StoreHandle base, std::string_view path) const {
         auto h = navigate(base, path);
@@ -329,7 +329,7 @@ protected:
     /**
      * @brief Implementation of commit. Must be provided by concrete class.
      */
-    [[nodiscard("Check for error on commit_impl")]]
+    [[nodiscard("Check for error on commit_impl"), gnu::warn_unused_result]]
     virtual std::expected<void,Error> commit_impl() = 0;
     /**
      * @brief Implementation of rollback. Must be provided by concrete class.

--- a/libs/core/include/oxide/core/store/store_handle.h
+++ b/libs/core/include/oxide/core/store/store_handle.h
@@ -20,7 +20,7 @@ struct OXIDE_CORE_API StoreHandle {
     /**
      * @brief Returns true if the handle is valid (nonzero).
      */
-    [[nodiscard("Check if handle is valid")]]
+    [[nodiscard("Check if handle is valid"), gnu::warn_unused_result]]
     constexpr bool valid() const noexcept { return raw != 0; }
 
     /**
@@ -28,7 +28,7 @@ struct OXIDE_CORE_API StoreHandle {
      * @param o The other handle.
      * @return True if both refer to the same node.
      */
-    [[nodiscard("Check if handles are equal")]]
+    [[nodiscard("Check if handles are equal"), gnu::warn_unused_result]]
     bool operator==(StoreHandle o) const noexcept { return raw == o.raw; }
 };
 

--- a/libs/core/include/oxide/core/time/clock.h
+++ b/libs/core/include/oxide/core/time/clock.h
@@ -10,7 +10,8 @@ class OXIDE_CORE_API IClock {
 public:
     virtual ~IClock() = default;
     
-    [[nodiscard]]
+    [[nodiscard, gnu::warn_unused_result]]
+
     virtual uint64_t now_ns() const = 0;
 };
 

--- a/libs/core/src/buffer/vector_buffer_impl.h
+++ b/libs/core/src/buffer/vector_buffer_impl.h
@@ -9,19 +9,19 @@ namespace oxide::core::detail {
 class OXIDE_CORE_API VectorBuffer final : public IBuffer {
     std::vector<std::byte> data_;
 public:
-    [[nodiscard("Handle resize result")]]
+    [[nodiscard("Handle resize result"), gnu::warn_unused_result]]
     std::expected<void, Error> resize(std::size_t bytes) override;
     
-    [[nodiscard("Handle reserve result")]]
+    [[nodiscard("Handle reserve result"), gnu::warn_unused_result]]
     std::expected<void, Error> reserve(std::size_t bytes) override;
     
-    [[nodiscard("Handle clear result")]]
+    [[nodiscard("Handle clear result"), gnu::warn_unused_result]]
     std::expected<void, Error> clear() override;
     
-    [[nodiscard("Handle shrinkToFit result")]]
+    [[nodiscard("Handle shrinkToFit result"), gnu::warn_unused_result]]
     std::expected<void, Error> shrink_to_fit() override;
     
-    [[nodiscard("Handle append result")]]
+    [[nodiscard("Handle append result"), gnu::warn_unused_result]]
     std::expected<void, Error> append(std::span<const std::byte> src) override;
 
     std::span<const std::byte> view() const noexcept override;

--- a/libs/core/src/storage/json_transaction_impl.h
+++ b/libs/core/src/storage/json_transaction_impl.h
@@ -27,33 +27,55 @@ public:
     JsonTransaction(nlohmann::json const& initial_data, JsonStore* store, JsonStoreOptions const& options);
     ~JsonTransaction() noexcept override;
 
-    [[nodiscard]] std::expected<StoreHandle, Error> root() const override;
-    [[nodiscard]] std::expected<bool, Error> get_bool(StoreHandle h) const override;
-    [[nodiscard]] std::expected<int64_t, Error> get_int(StoreHandle h) const override;
-    [[nodiscard]] std::expected<double, Error> get_double(StoreHandle h) const override;
-    [[nodiscard]] std::expected<std::string, Error> get_string(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> root() const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<bool, Error> get_bool(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<int64_t, Error> get_int(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<double, Error> get_double(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<std::string, Error> get_string(StoreHandle h) const override;
 
-    [[nodiscard]] std::expected<void, Error> set_bool(StoreHandle h, bool v) override;
-    [[nodiscard]] std::expected<void, Error> set_int(StoreHandle h, int64_t v) override;
-    [[nodiscard]] std::expected<void, Error> set_double(StoreHandle h, double v) override;
-    [[nodiscard]] std::expected<void, Error> set_string(StoreHandle h, std::string_view v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_bool(StoreHandle h, bool v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_int(StoreHandle h, int64_t v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_double(StoreHandle h, double v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_string(StoreHandle h, std::string_view v) override;
 
-    [[nodiscard]] std::expected<StoreHandle, Error> make_array(StoreHandle parent, std::string_view key) override;
-    [[nodiscard]] std::expected<StoreHandle, Error> make_object(StoreHandle parent, std::string_view key) override;
-    [[nodiscard]] std::expected<void, Error> make_bool(StoreHandle parent, std::string_view key, bool v) override;
-    [[nodiscard]] std::expected<void, Error> make_int(StoreHandle parent, std::string_view key, int64_t v) override;
-    [[nodiscard]] std::expected<void, Error> make_double(StoreHandle parent, std::string_view key, double v) override;
-    [[nodiscard]] std::expected<void, Error> make_string(StoreHandle parent, std::string_view key, std::string_view v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> make_array(StoreHandle parent, std::string_view key) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> make_object(StoreHandle parent, std::string_view key) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_bool(StoreHandle parent, std::string_view key, bool v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_int(StoreHandle parent, std::string_view key, int64_t v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_double(StoreHandle parent, std::string_view key, double v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_string(StoreHandle parent, std::string_view key, std::string_view v) override;
 
-    [[nodiscard]] std::expected<void, Error> remove(StoreHandle parent, std::string_view key) override;
-    [[nodiscard]] std::expected<bool, Error> has(StoreHandle parent, std::string_view key) const override;
-    [[nodiscard]] std::expected<void, Error> erase_element(StoreHandle parent, size_t idx) override;
-    [[nodiscard]] std::expected<bool, Error> has_element(StoreHandle parent, size_t idx) const override;
-    [[nodiscard]] std::expected<StoreHandle, Error> child(StoreHandle parent, std::string_view key) const override;
-    [[nodiscard]] std::expected<StoreHandle, Error> element(StoreHandle parent, size_t idx) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> remove(StoreHandle parent, std::string_view key) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<bool, Error> has(StoreHandle parent, std::string_view key) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> erase_element(StoreHandle parent, size_t idx) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<bool, Error> has_element(StoreHandle parent, size_t idx) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> child(StoreHandle parent, std::string_view key) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> element(StoreHandle parent, size_t idx) const override;
 
 private:
-    [[nodiscard]] std::expected<void, Error> commit_impl() override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> commit_impl() override;
     void rollback_impl() noexcept override;
 
     // Node representation for handle mapping
@@ -67,14 +89,22 @@ private:
     mutable std::unordered_map<uint64_t, Node> handle_map_;
     mutable uint64_t next_handle_ = 1;
     
-    [[nodiscard]] StoreHandle make_handle(std::vector<std::string> path) const;
-    [[nodiscard]] nlohmann::json* get_node(StoreHandle h);
-    [[nodiscard]] nlohmann::json const* get_node(StoreHandle h) const;
-    [[nodiscard]] std::expected<nlohmann::json*, Error> get_node_checked(StoreHandle h);
-    [[nodiscard]] std::expected<nlohmann::json const*, Error> get_node_checked(StoreHandle h) const;
-    [[nodiscard]] nlohmann::json* navigate_to_node(std::vector<std::string> const& path);
-    [[nodiscard]] nlohmann::json const* navigate_to_node(std::vector<std::string> const& path) const;
-    [[nodiscard]] bool is_valid_key(std::string_view key) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ StoreHandle make_handle(std::vector<std::string> path) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ nlohmann::json* get_node(StoreHandle h);
+    [[nodiscard, gnu::warn_unused_result]]
+ nlohmann::json const* get_node(StoreHandle h) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<nlohmann::json*, Error> get_node_checked(StoreHandle h);
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<nlohmann::json const*, Error> get_node_checked(StoreHandle h) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ nlohmann::json* navigate_to_node(std::vector<std::string> const& path);
+    [[nodiscard, gnu::warn_unused_result]]
+ nlohmann::json const* navigate_to_node(std::vector<std::string> const& path) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ bool is_valid_key(std::string_view key) const;
 };
 
 } // namespace oxide::core::detail

--- a/libs/core/src/storage/toml_transaction_impl.h
+++ b/libs/core/src/storage/toml_transaction_impl.h
@@ -26,33 +26,55 @@ public:
     TomlTransaction(toml::table const& initial_data, TomlStore* store, TomlStoreOptions const& options);
     ~TomlTransaction() noexcept override;
 
-    [[nodiscard]] std::expected<StoreHandle, Error> root() const override;
-    [[nodiscard]] std::expected<bool, Error> get_bool(StoreHandle h) const override;
-    [[nodiscard]] std::expected<int64_t, Error> get_int(StoreHandle h) const override;
-    [[nodiscard]] std::expected<double, Error> get_double(StoreHandle h) const override;
-    [[nodiscard]] std::expected<std::string, Error> get_string(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> root() const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<bool, Error> get_bool(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<int64_t, Error> get_int(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<double, Error> get_double(StoreHandle h) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<std::string, Error> get_string(StoreHandle h) const override;
 
-    [[nodiscard]] std::expected<void, Error> set_bool(StoreHandle h, bool v) override;
-    [[nodiscard]] std::expected<void, Error> set_int(StoreHandle h, int64_t v) override;
-    [[nodiscard]] std::expected<void, Error> set_double(StoreHandle h, double v) override;
-    [[nodiscard]] std::expected<void, Error> set_string(StoreHandle h, std::string_view v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_bool(StoreHandle h, bool v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_int(StoreHandle h, int64_t v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_double(StoreHandle h, double v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> set_string(StoreHandle h, std::string_view v) override;
 
-    [[nodiscard]] std::expected<StoreHandle, Error> make_array(StoreHandle parent, std::string_view key) override;
-    [[nodiscard]] std::expected<StoreHandle, Error> make_object(StoreHandle parent, std::string_view key) override;
-    [[nodiscard]] std::expected<void, Error> make_bool(StoreHandle parent, std::string_view key, bool v) override;
-    [[nodiscard]] std::expected<void, Error> make_int(StoreHandle parent, std::string_view key, int64_t v) override;
-    [[nodiscard]] std::expected<void, Error> make_double(StoreHandle parent, std::string_view key, double v) override;
-    [[nodiscard]] std::expected<void, Error> make_string(StoreHandle parent, std::string_view key, std::string_view v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> make_array(StoreHandle parent, std::string_view key) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> make_object(StoreHandle parent, std::string_view key) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_bool(StoreHandle parent, std::string_view key, bool v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_int(StoreHandle parent, std::string_view key, int64_t v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_double(StoreHandle parent, std::string_view key, double v) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> make_string(StoreHandle parent, std::string_view key, std::string_view v) override;
 
-    [[nodiscard]] std::expected<void, Error> remove(StoreHandle parent, std::string_view key) override;
-    [[nodiscard]] std::expected<bool, Error> has(StoreHandle parent, std::string_view key) const override;
-    [[nodiscard]] std::expected<void, Error> erase_element(StoreHandle parent, size_t idx) override;
-    [[nodiscard]] std::expected<bool, Error> has_element(StoreHandle parent, size_t idx) const override;
-    [[nodiscard]] std::expected<StoreHandle, Error> child(StoreHandle parent, std::string_view key) const override;
-    [[nodiscard]] std::expected<StoreHandle, Error> element(StoreHandle parent, size_t idx) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> remove(StoreHandle parent, std::string_view key) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<bool, Error> has(StoreHandle parent, std::string_view key) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> erase_element(StoreHandle parent, size_t idx) override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<bool, Error> has_element(StoreHandle parent, size_t idx) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> child(StoreHandle parent, std::string_view key) const override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<StoreHandle, Error> element(StoreHandle parent, size_t idx) const override;
 
 private:
-    [[nodiscard]] std::expected<void, Error> commit_impl() override;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<void, Error> commit_impl() override;
     void rollback_impl() noexcept override;
 
     // Node representation for handle mapping
@@ -66,14 +88,22 @@ private:
     mutable std::unordered_map<uint64_t, Node> handle_map_;
     mutable uint64_t next_handle_ = 1;
     
-    [[nodiscard]] StoreHandle make_handle(std::vector<std::string> path) const;
-    [[nodiscard]] toml::node* get_node(StoreHandle h);
-    [[nodiscard]] toml::node const* get_node(StoreHandle h) const;
-    [[nodiscard]] std::expected<toml::node*, Error> get_node_checked(StoreHandle h);
-    [[nodiscard]] std::expected<toml::node const*, Error> get_node_checked(StoreHandle h) const;
-    [[nodiscard]] toml::node* navigate_to_node(std::vector<std::string> const& path);
-    [[nodiscard]] toml::node const* navigate_to_node(std::vector<std::string> const& path) const;
-    [[nodiscard]] bool is_valid_key(std::string_view key) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ StoreHandle make_handle(std::vector<std::string> path) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ toml::node* get_node(StoreHandle h);
+    [[nodiscard, gnu::warn_unused_result]]
+ toml::node const* get_node(StoreHandle h) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<toml::node*, Error> get_node_checked(StoreHandle h);
+    [[nodiscard, gnu::warn_unused_result]]
+ std::expected<toml::node const*, Error> get_node_checked(StoreHandle h) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ toml::node* navigate_to_node(std::vector<std::string> const& path);
+    [[nodiscard, gnu::warn_unused_result]]
+ toml::node const* navigate_to_node(std::vector<std::string> const& path) const;
+    [[nodiscard, gnu::warn_unused_result]]
+ bool is_valid_key(std::string_view key) const;
 };
 
 } // namespace oxide::core

--- a/libs/core/tests/toml-test/toml-test.cpp
+++ b/libs/core/tests/toml-test/toml-test.cpp
@@ -285,7 +285,8 @@ TEST_CASE("TOML Transaction - ACID Properties", "[storage][toml][acid]") {
         }
         
         // Close and reopen
-        store->close();
+        auto close_result = store->close();
+        REQUIRE(close_result.has_value());
         
         auto new_store = make_toml_file_store(temp.path(), opts);
         REQUIRE(new_store.has_value());
@@ -345,11 +346,11 @@ TEST_CASE("TOML Transaction - Complex Data Structures", "[storage][toml]") {
         auto database = (*txn)->make_object(*server, "database");
         REQUIRE(database.has_value());
         
-        auto host = (*txn)->make_string(*database, "host", "localhost");
-        REQUIRE(host.has_value());
+        auto host_result = (*txn)->make_string(*database, "host", "localhost");
+        REQUIRE(host_result.has_value());
         
-        auto port = (*txn)->make_int(*database, "port", 5432);
-        REQUIRE(port.has_value());
+        auto port_result = (*txn)->make_int(*database, "port", 5432);
+        REQUIRE(port_result.has_value());
         
         // Navigate using the helper
         auto db_host = (*txn)->get<std::string>(*root, "server.database.host");
@@ -544,10 +545,17 @@ TEST_CASE("TOML Transaction - Update Operations", "[storage][toml]") {
             auto root = (*txn)->root();
             REQUIRE(root.has_value());
             
-            (*txn)->make_int(*root, "counter", 1);
-            (*txn)->make_string(*root, "status", "initial");
-            (*txn)->make_bool(*root, "active", false);
-            (*txn)->make_double(*root, "ratio", 0.5);
+            auto counter_result = (*txn)->make_int(*root, "counter", 1);
+            REQUIRE(counter_result.has_value());
+            
+            auto status_result = (*txn)->make_string(*root, "status", "initial");
+            REQUIRE(status_result.has_value());
+            
+            auto active_result = (*txn)->make_bool(*root, "active", false);
+            REQUIRE(active_result.has_value());
+            
+            auto ratio_result = (*txn)->make_double(*root, "ratio", 0.5);
+            REQUIRE(ratio_result.has_value());
             
             auto commit = (*txn)->commit();
             REQUIRE(commit.has_value());
@@ -621,14 +629,20 @@ TEST_CASE("TOML Transaction - Update Operations", "[storage][toml]") {
             auto root = (*txn)->root();
             REQUIRE(root.has_value());
             
-            (*txn)->make_string(*root, "keep_me", "value");
-            (*txn)->make_string(*root, "remove_me", "value");
+            auto keep_result = (*txn)->make_string(*root, "keep_me", "value");
+            REQUIRE(keep_result.has_value());
+            
+            auto remove_result = (*txn)->make_string(*root, "remove_me", "value");
+            REQUIRE(remove_result.has_value());
             
             auto obj = (*txn)->make_object(*root, "nested");
             REQUIRE(obj.has_value());
             
-            (*txn)->make_string(*obj, "child1", "value1");
-            (*txn)->make_string(*obj, "child2", "value2");
+            auto child1_result = (*txn)->make_string(*obj, "child1", "value1");
+            REQUIRE(child1_result.has_value());
+            
+            auto child2_result = (*txn)->make_string(*obj, "child2", "value2");
+            REQUIRE(child2_result.has_value());
             
             auto commit = (*txn)->commit();
             REQUIRE(commit.has_value());
@@ -711,23 +725,29 @@ TEST_CASE("TOML Store - File Format", "[storage][toml]") {
             REQUIRE(root.has_value());
             
             // Create a typical config structure
-            (*txn)->make_string(*root, "title", "TOML Example");
+            auto title_result = (*txn)->make_string(*root, "title", "TOML Example");
+            REQUIRE(title_result.has_value());
             
             auto owner = (*txn)->make_object(*root, "owner");
             REQUIRE(owner.has_value());
-            (*txn)->make_string(*owner, "name", "Tom Preston-Werner");
+            auto owner_name_result = (*txn)->make_string(*owner, "name", "Tom Preston-Werner");
+            REQUIRE(owner_name_result.has_value());
             
             auto database = (*txn)->make_object(*root, "database");
             REQUIRE(database.has_value());
-            (*txn)->make_string(*database, "server", "192.168.1.1");
-            (*txn)->make_int(*database, "port", 5432);
-            (*txn)->make_bool(*database, "enabled", true);
+            auto server_result = (*txn)->make_string(*database, "server", "192.168.1.1");
+            REQUIRE(server_result.has_value());
+            auto port_result = (*txn)->make_int(*database, "port", 5432);
+            REQUIRE(port_result.has_value());
+            auto enabled_result = (*txn)->make_bool(*database, "enabled", true);
+            REQUIRE(enabled_result.has_value());
             
             auto commit = (*txn)->commit();
             REQUIRE(commit.has_value());
         }
         
-        (*store)->close();
+        auto close_result = (*store)->close();
+        REQUIRE(close_result.has_value());
         
         // Read the file and verify it's valid TOML
         std::string content = temp.read();


### PR DESCRIPTION
bug(core): gcc-8+ doesn't fully support [[nodiscard]]

We have to use gnu::warn_unused_result. I went ahead and added this to the C++ Manual.